### PR TITLE
Handle case for invalid fighter name

### DIFF
--- a/lib/mma/index.js
+++ b/lib/mma/index.js
@@ -102,61 +102,66 @@ var fighter = function(query, callback) {
     //  Crawl and Parse Sherdog Profile
     //  https://github.com/valish/sherdog-api
     //------------------------------------------+
-    sherdog.getFighter(sherdog_url, function(data) {
-      fighter.name = data.name;
-      fighter.nickname = data.nickname;
-      fighter.association = data.association;
-      fighter.age = data.age;
-      fighter.birthday = data.birthday;
-      fighter.hometown = data.locality;
-      fighter.nationality = data.nationality;
-      fighter.height = data.height;
-      fighter.weight = data.weight;
-      fighter.weight_class = data.weight_class;
-      fighter.wins = data.wins;
-      fighter.losses = data.losses;
-      fighter.fights = data.fights;
-
-      // Search for UFC profile
-      google(query + ' ufc', function(err, next, links) {
-        if (err) console.error(err);
-        
-        for (var i = 0; i < links.length; ++i) {
-          if (resultContains(links[i], "ufc.com/fighter/")) {
-            ufc_url = links[i].href;
-            i = 10;
+    if (sherdog_url) {
+      sherdog.getFighter(sherdog_url, function(data) {
+        fighter.name = data.name;
+        fighter.nickname = data.nickname;
+        fighter.association = data.association;
+        fighter.age = data.age;
+        fighter.birthday = data.birthday;
+        fighter.hometown = data.locality;
+        fighter.nationality = data.nationality;
+        fighter.height = data.height;
+        fighter.weight = data.weight;
+        fighter.weight_class = data.weight_class;
+        fighter.wins = data.wins;
+        fighter.losses = data.losses;
+        fighter.fights = data.fights;
+  
+        // Search for UFC profile
+        google(query + ' ufc', function(err, next, links) {
+          if (err) console.error(err);
+          
+          for (var i = 0; i < links.length; ++i) {
+            if (resultContains(links[i], "ufc.com/fighter/")) {
+              ufc_url = links[i].href;
+              i = 10;
+            }
           }
-        }
-        
-        //------------------------------------------+
-        //  Crawl and Parse UFC Profile
-        //  https://github.com/valish/ufc-api
-        //------------------------------------------+
-        if (ufc_url) {
-          ufc.getFighter(ufc_url, function(data) {
-            fighter.fullname = data.fullname;
-            fighter.hometown = data.hometown;
-            fighter.location = data.location;
-            fighter.height = data.height;
-            fighter.height_cm = data.height_cm;
-            fighter.weight = data.weight;
-            fighter.weight_kg = data.weight_kg;
-            fighter.record = data.record;
-            fighter.college = data.college;
-            fighter.degree = data.degree;
-            fighter.summary = data.summary;
-            fighter.strikes = data.strikes;
-            fighter.takedowns = data.takedowns;
-            
+          
+          //------------------------------------------+
+          //  Crawl and Parse UFC Profile
+          //  https://github.com/valish/ufc-api
+          //------------------------------------------+
+          if (ufc_url) {
+            ufc.getFighter(ufc_url, function(data) {
+              fighter.fullname = data.fullname;
+              fighter.hometown = data.hometown;
+              fighter.location = data.location;
+              fighter.height = data.height;
+              fighter.height_cm = data.height_cm;
+              fighter.weight = data.weight;
+              fighter.weight_kg = data.weight_kg;
+              fighter.record = data.record;
+              fighter.college = data.college;
+              fighter.degree = data.degree;
+              fighter.summary = data.summary;
+              fighter.strikes = data.strikes;
+              fighter.takedowns = data.takedowns;
+              
+              callback(fighter);
+            });
+          } else {
             callback(fighter);
-          });
-        } else {
-          callback(fighter);
-        }
+          }
+        });
+        
       });
-      
-    });
-
+    }
+    else {
+      fighter = null;
+      callback(fighter);
+    }
   });
 }
 


### PR DESCRIPTION
This will prevent the app from sending an 'undefined' query to request causing it to crash.
Instead the API will return fighter 'null' so any app can handle that gracefully.